### PR TITLE
Move theme toggle to top bar with view-transition wipe

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -237,3 +237,17 @@ code[data-line-numbers-max-digits="3"] > [data-line]::before {
     @apply relative before:absolute before:left-[-1.67rem] before:top-[1.125rem] before:h-3 before:w-3 before:rounded-full before:border-2 before:border-muted before:bg-background;
   }
 }
+
+/* Theme toggle: View Transitions API circular wipe. The default cross-fade is
+   disabled so the JS animation in mode-toggle.tsx fully owns the transition. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+::view-transition-old(root) {
+  z-index: 1;
+}
+::view-transition-new(root) {
+  z-index: 2;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import "./globals.css";
 import { Navbar } from "@/components/layout/TopNavbar";
 import { DATA } from "@/data/resume";
 import Link from "next/link";
-import { ModeToggle } from "@/components/mode-toggle";
 import { Icons } from "@/components/icons";
 import { ThemeProvider } from "@/components/theme-provider";
 import { siteConfig } from "@/config/site";
@@ -69,9 +68,6 @@ export default function RootLayout({
                     </a>
                   </DockIcon>
                 ))}
-              <DockIcon>
-                <ModeToggle className="size-12 flex items-center justify-center" />
-              </DockIcon>
             </Dock>
           </div>
         </ThemeProvider>

--- a/src/components/layout/TopNavbar.tsx
+++ b/src/components/layout/TopNavbar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { siteConfig } from "@/config/site";
 import { Icons } from "@/components/icons";
+import { ModeToggle } from "@/components/mode-toggle";
 import { Menu, X } from "lucide-react";
 import { useState } from "react";
 
@@ -81,19 +82,24 @@ export function Navbar() {
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center gap-6">
             <NavItems />
+            <ModeToggle />
           </div>
 
-          {/* Mobile Menu Button */}
-          <button
-            onClick={() => setIsOpen(!isOpen)}
-            className="md:hidden p-2"
-          >
-            {isOpen ? (
-              <X className="h-6 w-6" />
-            ) : (
-              <Menu className="h-6 w-6" />
-            )}
-          </button>
+          {/* Mobile top-right: theme toggle + menu button */}
+          <div className="md:hidden flex items-center gap-1">
+            <ModeToggle />
+            <button
+              onClick={() => setIsOpen(!isOpen)}
+              aria-label="Toggle menu"
+              className="p-2"
+            >
+              {isOpen ? (
+                <X className="h-6 w-6" />
+              ) : (
+                <Menu className="h-6 w-6" />
+              )}
+            </button>
+          </div>
         </div>
 
         {/* Mobile Navigation */}

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,19 +1,80 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { MoonIcon, SunIcon } from "@radix-ui/react-icons";
 import { useTheme } from "next-themes";
+import { useRef } from "react";
+import { flushSync } from "react-dom";
 
-export function ModeToggle() {
-  const { theme, setTheme } = useTheme();
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  className?: string;
+}
+
+// View Transitions API circular wipe: clicking the toggle expands a circle
+// from the button's center across the viewport, revealing the new theme
+// underneath. Falls back to an instant swap on browsers without the API and
+// when the user prefers reduced motion.
+export function ModeToggle({ className }: Props) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const ref = useRef<HTMLButtonElement>(null);
+
+  const toggle = async () => {
+    const next = resolvedTheme === "dark" ? "light" : "dark";
+
+    const supportsTransitions =
+      typeof document !== "undefined" &&
+      // @ts-expect-error - startViewTransition is not yet in lib.dom typings
+      typeof document.startViewTransition === "function";
+    const prefersReducedMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (!supportsTransitions || prefersReducedMotion || !ref.current) {
+      setTheme(next);
+      return;
+    }
+
+    const rect = ref.current.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+    const maxRadius = Math.hypot(
+      Math.max(x, window.innerWidth - x),
+      Math.max(y, window.innerHeight - y),
+    );
+
+    // @ts-expect-error - startViewTransition is not yet in lib.dom typings
+    const transition = document.startViewTransition(() => {
+      flushSync(() => setTheme(next));
+    });
+
+    await transition.ready;
+
+    document.documentElement.animate(
+      {
+        clipPath: [
+          `circle(0px at ${x}px ${y}px)`,
+          `circle(${maxRadius}px at ${x}px ${y}px)`,
+        ],
+      },
+      {
+        duration: 600,
+        easing: "cubic-bezier(0.4, 0, 0.2, 1)",
+        pseudoElement: "::view-transition-new(root)",
+      },
+    );
+  };
 
   return (
     <Button
+      ref={ref}
       variant="ghost"
       type="button"
       size="icon"
-      className="px-2"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      aria-label="Toggle theme"
+      className={cn("px-2", className)}
+      onClick={toggle}
     >
       <SunIcon className="h-[1.2rem] w-[1.2rem] text-neutral-800 dark:hidden dark:text-neutral-200" />
       <MoonIcon className="hidden h-[1.2rem] w-[1.2rem] text-neutral-800 dark:block dark:text-neutral-200" />

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,5 +1,4 @@
 import { Dock, DockIcon } from "@/components/magicui/dock";
-import { ModeToggle } from "@/components/mode-toggle";
 import { buttonVariants } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -59,17 +58,6 @@ export default function Navbar() {
               </Tooltip>
             </DockIcon>
           ))}
-        <Separator orientation="vertical" className="h-full py-2" />
-        <DockIcon>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ModeToggle />
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Theme</p>
-            </TooltipContent>
-          </Tooltip>
-        </DockIcon>
       </Dock>
     </div>
   );


### PR DESCRIPTION
## Summary
- Theme toggle moves from the bottom dock to the top bar — desktop right edge, mobile top-right next to the menu button
- Clicking starts a View Transitions API animation: a circle expands from the button's position across the viewport, revealing the new theme
- Falls back to an instant swap on browsers without \`document.startViewTransition\` and when \`prefers-reduced-motion: reduce\` is set
- Default cross-fade disabled via \`globals.css\` so the JS-driven clip-path owns the animation

## Test plan
- [ ] Toggle from light to dark on desktop — circle wipes from top-right
- [ ] Toggle from dark to light on mobile — circle wipes from top-right corner
- [ ] Bottom dock no longer has theme button; width fits 390px viewport
- [ ] Safari < 18 or reduced-motion: theme still swaps, just without animation